### PR TITLE
Handle non-OK API connection responses

### DIFF
--- a/src/components/ApiCredentials.tsx
+++ b/src/components/ApiCredentials.tsx
@@ -54,22 +54,16 @@ export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({
       // Add debug information
       setDebugInfo(`Attempting connection to: ${credentials.baseUrl}\nUsername: ${credentials.username}\nTesting authentication...`);
       
-      const isConnected = await client.testConnection();
-      
-      if (isConnected) {
-        setValidationStatus('success');
-        setDebugInfo('Connection successful! Server responded correctly.');
-        onCredentialsValidated(credentials, client);
-      } else {
-        setValidationStatus('error');
-        setError('Failed to connect to the API. This could be due to:\n• Incorrect URL or server not reachable\n• Network connectivity issues\n• Server is down or not responding\n• CORS policy blocking the request');
-        setDebugInfo('Check the browser console for more detailed error information.');
-      }
+      await client.testConnection();
+
+      setValidationStatus('success');
+      setDebugInfo('Connection successful! Server responded correctly.');
+      onCredentialsValidated(credentials, client);
     } catch (err) {
       setValidationStatus('error');
       const errorMessage = err instanceof Error ? err.message : 'Connection failed';
-      setError(`Connection error: ${errorMessage}`);
-      setDebugInfo('This is typically a network connectivity issue or CORS policy restriction.');
+      setError(errorMessage);
+      setDebugInfo('Check the browser console for more detailed error information.');
     } finally {
       setIsValidating(false);
     }

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -26,17 +26,19 @@ export class ApiClient {
     try {
       console.log('Testing connection to:', this.credentials.baseUrl);
       console.log('Using username:', this.credentials.username);
-      
+
       const response = await this.makeRequest(this.credentials.baseUrl);
       console.log('Response status:', response.status);
       console.log('Response headers:', Object.fromEntries(response.headers.entries()));
-      
-      // Accept any response that indicates the server is reachable and credentials are being processed
-      // This includes 200, 401 (unauthorized but server responded), 403 (forbidden but server responded)
-      return response.status < 500;
+
+      if (!response.ok) {
+        throw new Error(`Connection failed: ${response.status} ${response.statusText}`);
+      }
+
+      return true;
     } catch (error) {
       console.error('Connection test failed:', error);
-      return false;
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- Throw detailed error when API connection response is not OK
- Surface connection error messages in the credentials form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 26 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688e3ce2027c832ab4d7c56c0ebfc2f8