### PR TITLE
fix: initialize response variable in connection test

### DIFF
--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -24,12 +24,10 @@ export class ApiClient {
 
   async testConnection(): Promise<boolean> {
     try {
-
-
+      const response = await this.makeRequest(this.credentials.baseUrl);
       if (!response.ok) {
         throw new Error(`Connection failed: ${response.status} ${response.statusText}`);
       }
-
       return true;
     } catch (error) {
       console.error('Connection test failed:', error);


### PR DESCRIPTION
## Summary
- ensure `testConnection` fetches the API base URL before verifying response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 24 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688e55f3fc18832aab3ff3eb9d152537