### PR TITLE
Handle API credential validation errors

### DIFF
--- a/src/components/ApiCredentials.tsx
+++ b/src/components/ApiCredentials.tsx
@@ -62,7 +62,8 @@ export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({
     } catch (err) {
       setValidationStatus('error');
       const errorMessage = err instanceof Error ? err.message : 'Connection failed';
-
+      setError(errorMessage);
+      console.error('Error validating credentials:', errorMessage);
       setDebugInfo('Check the browser console for more detailed error information.');
     } finally {
       setIsValidating(false);


### PR DESCRIPTION
## Summary
- surface validation errors in `ApiCredentials` by calling `setError` when connection fails
- log validation errors to the console for easier debugging

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e57f8f634832aa4ade4bac25bbd7c