### PR TITLE
Fix preview payload to use rows array

### DIFF
--- a/src/components/DataMapping.tsx
+++ b/src/components/DataMapping.tsx
@@ -58,7 +58,7 @@ export const DataMapping: React.FC<DataMappingProps> = ({
   };
 
   const generatePreviewPayload = (rowIndex: number) => {
-    const row = spreadsheetData.roots[rowIndex];
+    const row = spreadsheetData.rows[rowIndex];
     const payload: any = {};
     
     mappings.forEach(mapping => {


### PR DESCRIPTION
## Summary
- fix DataMapping preview to use `spreadsheetData.rows`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 23 errors, 2 warnings)
- `npm run build`
- `curl -x "" -I http://127.0.0.1:5174/S4_API/`
- `node <script>`

------
https://chatgpt.com/codex/tasks/task_e_688e59a805f4832aadfa13a4930c6d82