### PR TITLE
feat: show detailed error page on API failures

### DIFF
--- a/src/components/ApiCredentials.tsx
+++ b/src/components/ApiCredentials.tsx
@@ -5,12 +5,14 @@ import { ApiClient } from '../utils/apiClient';
 
 interface ApiCredentialsProps {
   onCredentialsValidated: (credentials: ApiCredentials, client: ApiClient) => void;
+  onError?: (message: string) => void;
   disabled?: boolean;
 }
 
-export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({ 
-  onCredentialsValidated, 
-  disabled 
+export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({
+  onCredentialsValidated,
+  onError,
+  disabled
 }) => {
   const [credentials, setCredentials] = useState<ApiCredentials>({
     baseUrl: '',
@@ -63,6 +65,7 @@ export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({
       setValidationStatus('error');
       const errorMessage = err instanceof Error ? err.message : 'Connection failed';
       setError(errorMessage);
+      onError?.(errorMessage);
       console.error('Error validating credentials:', errorMessage);
       setDebugInfo('Check the browser console for more detailed error information.');
     } finally {

--- a/src/components/EndpointDiscovery.tsx
+++ b/src/components/EndpointDiscovery.tsx
@@ -6,12 +6,14 @@ import { ApiClient } from '../utils/apiClient';
 interface EndpointDiscoveryProps {
   apiClient: ApiClient;
   onEndpointSelected: (endpoint: ApiEndpoint) => void;
+  onError?: (message: string) => void;
   disabled?: boolean;
 }
 
 export const EndpointDiscovery: React.FC<EndpointDiscoveryProps> = ({
   apiClient,
   onEndpointSelected,
+  onError,
   disabled
 }) => {
   const [endpoints, setEndpoints] = useState<ApiEndpoint[]>([]);
@@ -37,7 +39,9 @@ export const EndpointDiscovery: React.FC<EndpointDiscoveryProps> = ({
         setError('No endpoints were discovered. The API may not expose OpenAPI documentation.');
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to discover endpoints');
+      const message = err instanceof Error ? err.message : 'Failed to discover endpoints';
+      setError(message);
+      onError?.(message);
     } finally {
       setIsDiscovering(false);
     }

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface ErrorPageProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export const ErrorPage: React.FC<ErrorPageProps> = ({ message, onRetry }) => {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <AlertTriangle className="h-12 w-12 text-red-600 mb-4" />
+      <h2 className="text-xl font-semibold mb-2">An error occurred</h2>
+      <pre className="max-w-full whitespace-pre-wrap bg-red-50 border border-red-200 p-4 rounded mb-4 text-sm text-red-800">
+        {message}
+      </pre>
+      <button
+        onClick={onRetry}
+        className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      >
+        Back to start
+      </button>
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add shared error handling with dedicated error page
- propagate errors from credential check, endpoint discovery, and data submission
- surface server error details in API client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 27 problems (25 errors, 2 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e5c4e6a0c832aa90fd64996cab4e3