### PR TITLE
refactor: build request headers dynamically

### DIFF
--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -10,13 +10,17 @@ export class ApiClient {
   }
 
   private async makeRequest(url: string, options: RequestInit = {}): Promise<Response> {
+    const headers = new Headers(options.headers || {});
+
+    headers.set('Authorization', this.authHeader);
+
+    if (options.body !== undefined && options.body !== null) {
+      headers.set('Content-Type', 'application/json');
+    }
+
     const response = await fetch(url, {
       ...options,
-      headers: {
-        'Authorization': this.authHeader,
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
+      headers,
     });
 
     return response;


### PR DESCRIPTION
## Summary
- build request headers dynamically in `ApiClient.makeRequest`
- only send `Content-Type: application/json` when a request body is provided

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 27 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688e68cdbdd4832aa75175766bae6c93