### PR TITLE
Surface network errors in ApiClient and credentials form

### DIFF
--- a/src/components/ApiCredentials.tsx
+++ b/src/components/ApiCredentials.tsx
@@ -66,8 +66,8 @@ export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({
       const errorMessage = err instanceof Error ? err.message : 'Connection failed';
       setError(errorMessage);
       onError?.(errorMessage);
-      console.error('Error validating credentials:', errorMessage);
-      setDebugInfo('Check the browser console for more detailed error information.');
+      console.error('Error validating credentials:', err);
+      setDebugInfo('This may indicate a network or CORS issue. Check the browser console for more details.');
     } finally {
       setIsValidating(false);
     }

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -10,16 +10,21 @@ export class ApiClient {
   }
 
   private async makeRequest(url: string, options: RequestInit = {}): Promise<Response> {
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        'Authorization': this.authHeader,
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
-    });
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          'Authorization': this.authHeader,
+          'Content-Type': 'application/json',
+          ...options.headers,
+        },
+      });
 
-    return response;
+      return response;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Network or CORS error: ${message}`);
+    }
   }
 
   async testConnection(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Wrap fetch with try/catch in ApiClient and throw a "Network or CORS error" message
- Surface network/CORS issues in the ApiCredentials form debug output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 problems (25 errors, 2 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688e68cccc88832aa682873a3f03d3f9