### PR TITLE
Fix missing try block in API client

### DIFF
--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -18,10 +18,11 @@ export class ApiClient {
       headers.set('Content-Type', 'application/json');
     }
 
-    const response = await fetch(url, {
-      ...options,
-      headers,
-    });
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers,
+      });
 
       return response;
     } catch (err) {


### PR DESCRIPTION
## Summary
- wrap `fetch` call in `ApiClient.makeRequest` with a `try` block to match existing `catch`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e76352014832abd523c3069157eea