### PR TITLE
Handle HTTP requests from HTTPS context

### DIFF
--- a/src/components/ApiCredentials.tsx
+++ b/src/components/ApiCredentials.tsx
@@ -61,13 +61,17 @@ export const ApiCredentialsForm: React.FC<ApiCredentialsProps> = ({
       setValidationStatus('success');
       setDebugInfo('Connection successful! Server responded correctly.');
       onCredentialsValidated(credentials, client);
-    } catch (err) {
+    } catch (err: unknown) {
       setValidationStatus('error');
       const errorMessage = err instanceof Error ? err.message : 'Connection failed';
       setError(errorMessage);
       onError?.(errorMessage);
       console.error('Error validating credentials:', err);
-      setDebugInfo('This may indicate a network or CORS issue. Check the browser console for more details.');
+      if (errorMessage.includes('insecure API over HTTP')) {
+        setDebugInfo('The page is served over HTTPS and browsers block calls to HTTP APIs. Use an HTTPS endpoint or configure a proxy.');
+      } else {
+        setDebugInfo('This may indicate a network or CORS issue. Check the browser console for more details.');
+      }
     } finally {
       setIsValidating(false);
     }


### PR DESCRIPTION
## Summary
- prevent mixed-content requests by detecting HTTP base URLs when app runs on HTTPS
- give clearer validation feedback when HTTP API is blocked

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npx eslint src/components/ApiCredentials.tsx src/utils/apiClient.ts`

------
https://chatgpt.com/codex/tasks/task_e_688e83bc52a8832a9b0dda5666d9992a